### PR TITLE
Genesis Skip Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # genesis-skip-link
 An accessible skip link for Genesis WordPress themes.
+
+Read the notes with each function and make sure to update the `theme_` portion of the function names appropriately.

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,50 @@
+<?php
+
+
+    /**
+     * Adds "inner" id to the site-inner content/sidebar wrap element on HTML5 child themes.
+     * Using inner, since Genesis uses this id when HTML5 is disabled.
+     * @param  array $attributes Array of element attributes
+     * @return array             Same array of element attributes with the id added
+     */
+    function theme_add_content_id( $attributes ) {
+        $attributes['id'] = "inner";
+
+        return $attributes;
+    }
+    add_filter( 'genesis_attr_site-inner', 'theme_add_content_id', 15 );
+
+
+    /**
+     * Add a link first thing after the body element that will skip to the inner element.
+     */
+    function theme_add_skip_link() {
+        echo '<a class="skip-link" href="#inner">Skip to content</a>';
+    }
+    add_action( 'get_header', 'theme_add_skip_link', 1 );
+
+    /**
+     * Semi-optional, tabindex fix for specific browsers. 
+     * Feel free to move it to your JS file instead. It's too short to warrant its own file enqueue.
+     * Read more: http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/
+     */
+    function theme_fix_tabindex() {
+    ?>
+
+    <script async type="text/javascript">
+        window.addEventListener("hashchange", function(event) {
+            var element = document.getElementById(location.hash.substring(1));
+
+            if (element) {
+                if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+                    element.tabIndex = -1;
+                }
+
+                element.focus();
+            }
+        }, false);
+    </script>
+    
+    <?php
+    }
+    add_action( 'wp_footer', 'theme_fix_tabindex' );

--- a/style.css
+++ b/style.css
@@ -1,0 +1,20 @@
+/* Base style, might need additional styling to stand out more. 
+   Positioned slightly off the top and left edges.
+*/
+.skip-link {
+    display: inline-block;
+    position: absolute;
+    top: 0.5em;
+    left: 0.5em;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    clip: rect(0, 0, 0, 0);
+}
+
+/* Unhide the link when it has keyboard focus */
+.skip-link:focus {
+    width: auto;
+    height: auto;
+    clip: auto;
+}


### PR DESCRIPTION
Here's this. :)

The `theme_fix_tabindex()` function applies to any skip link and not really just Genesis - it's a stupid browser bug that has been around forever.

Code might need additional testing on all the various child themes Studiopress provides to make sure the hooks work as expected, especially on older themes. Definitely works on the Genesis Sample theme they provide though, with and without HTML5 theme support.