### PR TITLE
Fixed hook being used

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,7 +21,7 @@
     function theme_add_skip_link() {
         echo '<a class="skip-link" href="#inner">Skip to content</a>';
     }
-    add_action( 'get_header', 'theme_add_skip_link', 1 );
+    add_action( 'genesis_before', 'theme_add_skip_link', 1 );
 
     /**
      * Tabindex fix for specific browsers to fix skip link.

--- a/functions.php
+++ b/functions.php
@@ -39,3 +39,4 @@
         wp_enqueue_script( 'theme_skiplink-fix' );
     }
     add_action( 'wp_enqueue_scripts', 'theme_fix_skiplink' );
+


### PR DESCRIPTION
Using `get_header` seems to put the link before the doctype declaration (even with an excessively high priority). Did not notice this before because devtools fixed the output for me. 